### PR TITLE
adding BehaviorSubject.value getter

### DIFF
--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -8,6 +8,8 @@ class BehaviorSubject<T> extends Subject<T> {
 
   T _value;
 
+  T get value = _value;
+
   @override
   void next(T value) => super.next(_value = value);
 

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -8,7 +8,7 @@ class BehaviorSubject<T> extends Subject<T> {
 
   T _value;
 
-  T get value = _value;
+  T get value => _value;
 
   @override
   void next(T value) => super.next(_value = value);


### PR DESCRIPTION
According to https://rxjs.dev/api/index/class/BehaviorSubject#properties the `BehaviorSubject`'s value should be exposed.