### PR TITLE
adding onDispose

### DIFF
--- a/lib/src/constructors/create.dart
+++ b/lib/src/constructors/create.dart
@@ -9,11 +9,11 @@ import '../disposables/disposable.dart';
 
 /// Creates an [Observable] that uses the provided `callback` to emit elements
 /// to the provided [Observer] on each subscribe.
-/// Optionally pass an [onDisponse] callback that will be called when the
+/// Optionally pass an [onDispose] callback that will be called when the
 /// subscription is cancelled.
 Observable<T> create<T>(Callback1<Subscriber<T>> callback,
-        {Callback0? onDisponse}) =>
-    CreateObservable<T>(callback, onDisponse);
+        {Callback0? onDispose}) =>
+    CreateObservable<T>(callback, onDispose);
 
 class CreateObservable<T> implements Observable<T> {
   CreateObservable(this.callback, this.dispose);

--- a/lib/src/constructors/create.dart
+++ b/lib/src/constructors/create.dart
@@ -1,36 +1,41 @@
 import 'package:more/functional.dart';
 
+import '../../disposables.dart';
 import '../core/observable.dart';
 import '../core/observer.dart';
 import '../core/subscriber.dart';
-import '../disposables/action.dart';
-import '../disposables/composite.dart';
-import '../disposables/disposable.dart';
 
 /// Creates an [Observable] that uses the provided `callback` to emit elements
 /// to the provided [Observer] on each subscribe.
-/// Optionally pass an [onDispose] callback that will be called when the
-/// subscription is cancelled.
-Observable<T> create<T>(Callback1<Subscriber<T>> callback,
-        {Callback0? onDispose}) =>
-    CreateObservable<T>(callback, onDispose);
+/// The `callback` may return a [Disposable] or a [Callback0] to be called when
+/// the subscription is disposed.
+Observable<T> create<T>(
+        Map1<Subscriber<T>, dynamic /* Disposable|Callback0|null */ >
+            callback) =>
+    CreateObservable<T>(callback);
 
 class CreateObservable<T> implements Observable<T> {
-  CreateObservable(this.callback, this.dispose);
+  CreateObservable(this.callback);
 
-  final Callback1<Subscriber<T>> callback;
-  final Callback0? dispose;
+  final Map1<Subscriber<T>, dynamic> callback;
 
   @override
   Disposable subscribe(Observer<T> observer) {
     final subscriber = Subscriber<T>(observer);
     try {
-      callback(subscriber);
+      final onDispose = callback(subscriber);
+      if (onDispose is Disposable) {
+        subscriber.add(onDispose);
+      } else if (onDispose is Callback0) {
+        subscriber.add(ActionDisposable(onDispose));
+      } else if (onDispose != null) {
+        subscriber.error(
+            Exception('Unknown return type: ${onDispose.runtimeType}'),
+            StackTrace.current);
+      }
     } catch (error, stackTrace) {
       subscriber.error(error, stackTrace);
     }
-    return dispose == null
-        ? subscriber
-        : CompositeDisposable([subscriber, ActionDisposable(dispose!)]);
+    return subscriber;
   }
 }

--- a/test/constructors_test.dart
+++ b/test/constructors_test.dart
@@ -133,6 +133,19 @@ void main() {
       });
       expect(actual, scheduler.isObservable<String>('(ab#)'));
     });
+    test('calls onDispose when unsubscribed', () {
+      var disposed = false;
+      final actual = create<String>((emitter) {
+        emitter.next('a');
+        emitter.next('b');
+      }, onDisponse: () {
+        disposed = true;
+      });
+      expect(actual, scheduler.isObservable<String>('(ab)'));
+      expect(disposed, isFalse);
+      actual.subscribe(Observer()).dispose();
+      expect(disposed, isTrue);
+    });
   });
   group('defer', () {
     test('complete value', () {

--- a/test/constructors_test.dart
+++ b/test/constructors_test.dart
@@ -138,8 +138,7 @@ void main() {
       final actual = create<String>((emitter) {
         emitter.next('a');
         emitter.next('b');
-      }, onDispose: () {
-        disposed = true;
+        return () => disposed = true;
       });
       expect(actual, scheduler.isObservable<String>('(ab)'));
       expect(disposed, isFalse);

--- a/test/constructors_test.dart
+++ b/test/constructors_test.dart
@@ -138,7 +138,7 @@ void main() {
       final actual = create<String>((emitter) {
         emitter.next('a');
         emitter.next('b');
-      }, onDisponse: () {
+      }, onDispose: () {
         disposed = true;
       });
       expect(actual, scheduler.isObservable<String>('(ab)'));


### PR DESCRIPTION
The `rxjs` `Observable` constructor allows passing a `subscribe` function that returns a `TeardowLogic`, which is a function that is called when subscription is cancelled. https://rxjs.dev/api/index/class/Observable#constructor

This PR adds a `onDispose` named parameter to the `create` constructor with the same purpose.