### PR TITLE
adding "inclusive" option to takeWhile

### DIFF
--- a/lib/src/operators/take_while.dart
+++ b/lib/src/operators/take_while.dart
@@ -8,28 +8,30 @@ import '../events/event.dart';
 
 extension TakeWhileOperator<T> on Observable<T> {
   /// Emits values while the [predicate] returns `true`.
-  Observable<T> takeWhile(Predicate1<T> predicate) =>
-      TakeWhileObservable<T>(this, predicate);
+  Observable<T> takeWhile(Predicate1<T> predicate, {bool inclusive = false}) =>
+      TakeWhileObservable<T>(this, predicate, inclusive);
 }
 
 class TakeWhileObservable<T> implements Observable<T> {
-  TakeWhileObservable(this.delegate, this.predicate);
+  TakeWhileObservable(this.delegate, this.predicate, this.inclusive);
 
   final Observable<T> delegate;
   final Predicate1<T> predicate;
+  final bool inclusive;
 
   @override
   Disposable subscribe(Observer<T> observer) {
-    final subscriber = TakeWhileSubscriber<T>(observer, predicate);
+    final subscriber = TakeWhileSubscriber<T>(observer, predicate, inclusive);
     subscriber.add(delegate.subscribe(subscriber));
     return subscriber;
   }
 }
 
 class TakeWhileSubscriber<T> extends Subscriber<T> {
-  TakeWhileSubscriber(Observer<T> super.observer, this.predicate);
+  TakeWhileSubscriber(Observer<T> super.observer, this.predicate, this.inclusive);
 
   final Predicate1<T> predicate;
+  final bool inclusive;
 
   @override
   void onNext(T value) {
@@ -39,6 +41,9 @@ class TakeWhileSubscriber<T> extends Subscriber<T> {
     } else if (predicateEvent.value) {
       doNext(value);
     } else {
+      if (inclusive) {
+        doNext(value);
+      }
       doComplete();
     }
   }

--- a/lib/src/operators/take_while.dart
+++ b/lib/src/operators/take_while.dart
@@ -28,7 +28,8 @@ class TakeWhileObservable<T> implements Observable<T> {
 }
 
 class TakeWhileSubscriber<T> extends Subscriber<T> {
-  TakeWhileSubscriber(Observer<T> super.observer, this.predicate, this.inclusive);
+  TakeWhileSubscriber(
+      Observer<T> super.observer, this.predicate, this.inclusive);
 
   final Predicate1<T> predicate;
   final bool inclusive;

--- a/test/operators_test.dart
+++ b/test/operators_test.dart
@@ -2332,7 +2332,8 @@ void main() {
     });
     test('multiple values completion (inclusive)', () {
       final input = scheduler.cold<String>('-a--b---c----|');
-      final actual = input.takeWhile((value) => 'ab'.contains(value), inclusive: true);
+      final actual =
+          input.takeWhile((value) => 'ab'.contains(value), inclusive: true);
       expect(actual, scheduler.isObservable<String>('-a--b---(c|)'));
     });
     test('multiple values and error', () {

--- a/test/operators_test.dart
+++ b/test/operators_test.dart
@@ -2325,10 +2325,15 @@ void main() {
       final actual = input.takeWhile((value) => 'ab'.contains(value));
       expect(actual, scheduler.isObservable<String>('--a--#'));
     });
-    test('multiple values completion', () {
+    test('multiple values completion (non-inclusive)', () {
       final input = scheduler.cold<String>('-a--b---c----|');
       final actual = input.takeWhile((value) => 'ab'.contains(value));
       expect(actual, scheduler.isObservable<String>('-a--b---|'));
+    });
+    test('multiple values completion (inclusive)', () {
+      final input = scheduler.cold<String>('-a--b---c----|');
+      final actual = input.takeWhile((value) => 'ab'.contains(value), inclusive: true);
+      expect(actual, scheduler.isObservable<String>('-a--b---(c|)'));
     });
     test('multiple values and error', () {
       final input = scheduler.cold<String>('-a--b---c----#');


### PR DESCRIPTION
`takeWhile` operator should accept an [`inclusive` option](https://rxjs.dev/api/index/function/takeWhile):

> When set to true the value that caused predicate to return false will also be emitted.